### PR TITLE
Add support for arrays and unions

### DIFF
--- a/src/PhpDocTypeReader.php
+++ b/src/PhpDocTypeReader.php
@@ -23,10 +23,12 @@ use PhpDocTypeReader\Type\IntType;
 use PhpDocTypeReader\Type\ObjectType;
 use PhpDocTypeReader\Type\StringType;
 use PhpDocTypeReader\Type\Type;
+use PhpDocTypeReader\Type\UnionType;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
@@ -135,14 +137,29 @@ final class PhpDocTypeReader
         if ($type_node instanceof ArrayTypeNode) {
             $type = $this->getTypeFromNodeType($type_node->type, $identifier_context);
             if (!($type instanceof AtomicType)) {
-                throw new \LogicException('unsupported array type parameter');
+                throw new \LogicException('unsupported array type');
             }
             return new ArrayType($type, []);
+        }
+        if ($type_node instanceof UnionTypeNode) {
+            $types = [];
+            foreach ($type_node->types as $type) {
+                $type = $this->getTypeFromNodeType($type, $identifier_context);
+                if (!($type instanceof AtomicType)) {
+                    throw new \LogicException('unsupported union type');
+                }
+
+                $types[] = $type;
+            }
+
+            return new UnionType($types);
         }
         /** @psalm-suppress ForbiddenCode */
         var_dump($type_node);
         throw new \LogicException('unsupported type');
     }
+
+
 
     private function tryGetClassNameFromIdentifier(
         IdentifierTypeNode $type,

--- a/src/PhpDocTypeReader.php
+++ b/src/PhpDocTypeReader.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace PhpDocTypeReader;
 
 use PhpDocTypeReader\Context\IdentifierContext;
+use PhpDocTypeReader\Type\ArrayType;
+use PhpDocTypeReader\Type\AtomicType;
 use PhpDocTypeReader\Type\BoolType;
 use PhpDocTypeReader\Type\FloatType;
 use PhpDocTypeReader\Type\GenericType;
@@ -111,6 +113,16 @@ final class PhpDocTypeReader
             }
         }
         if ($type_node instanceof GenericTypeNode) {
+            if ($type_node->type->name === 'array') {
+                // Only one atomic type argument is allowed for now
+                $type = $this->getTypeFromNodeType($type_node->genericTypes[0], $identifier_context);
+                if (!($type instanceof AtomicType)) {
+                    throw new \LogicException('unsupported array type parameter');
+                }
+
+                return new ArrayType($type, []);
+            }
+
             return new GenericType(
                 new ObjectType($this->tryGetClassNameFromIdentifier($type_node->type, $identifier_context)),
                 array_map(

--- a/src/PhpDocTypeReader.php
+++ b/src/PhpDocTypeReader.php
@@ -23,6 +23,7 @@ use PhpDocTypeReader\Type\IntType;
 use PhpDocTypeReader\Type\ObjectType;
 use PhpDocTypeReader\Type\StringType;
 use PhpDocTypeReader\Type\Type;
+use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
@@ -130,6 +131,13 @@ final class PhpDocTypeReader
                     $type_node->genericTypes
                 )
             );
+        }
+        if ($type_node instanceof ArrayTypeNode) {
+            $type = $this->getTypeFromNodeType($type_node->type, $identifier_context);
+            if (!($type instanceof AtomicType)) {
+                throw new \LogicException('unsupported array type parameter');
+            }
+            return new ArrayType($type, []);
         }
         /** @psalm-suppress ForbiddenCode */
         var_dump($type_node);

--- a/tests/PhpDocTypeReaderTest.php
+++ b/tests/PhpDocTypeReaderTest.php
@@ -17,6 +17,7 @@ use PhpDocTypeReader\Context\IdentifierContext;
 use PhpDocTypeReader\Context\RawIdentifierContext;
 use PhpDocTypeReader\ExampleTypes\ExampleGenericType;
 use PhpDocTypeReader\ExampleTypes\ExampleType;
+use PhpDocTypeReader\Type\ArrayType;
 use PhpDocTypeReader\Type\BoolType;
 use PhpDocTypeReader\Type\FloatType;
 use PhpDocTypeReader\Type\GenericType;
@@ -195,7 +196,14 @@ class PhpDocTypeReaderTest extends TestCase
                 new RawIdentifierContext(
                     'PhpDocTypeReader\\ExampleTypes',
                     []
-                )
+                ),
+            ],
+            [
+                [
+                    'array_var' => new ArrayType(new IntType(), []),
+                ],
+                '/** @param array<int> $array_var */',
+                $default_identifier_context,
             ],
         ];
     }

--- a/tests/PhpDocTypeReaderTest.php
+++ b/tests/PhpDocTypeReaderTest.php
@@ -24,6 +24,7 @@ use PhpDocTypeReader\Type\GenericType;
 use PhpDocTypeReader\Type\IntType;
 use PhpDocTypeReader\Type\ObjectType;
 use PhpDocTypeReader\Type\StringType;
+use PhpDocTypeReader\Type\UnionType;
 use PHPUnit\Framework\TestCase;
 
 class PhpDocTypeReaderTest extends TestCase
@@ -210,6 +211,13 @@ class PhpDocTypeReaderTest extends TestCase
                     'array_var' => new ArrayType(new IntType(), []),
                 ],
                 '/** @param int[] $array_var */',
+                $default_identifier_context,
+            ],
+            [
+                [
+                    'union_var' => new UnionType([new IntType(), new StringType()]),
+                ],
+                '/** @param int|string $union_var */',
                 $default_identifier_context,
             ],
         ];

--- a/tests/PhpDocTypeReaderTest.php
+++ b/tests/PhpDocTypeReaderTest.php
@@ -205,6 +205,13 @@ class PhpDocTypeReaderTest extends TestCase
                 '/** @param array<int> $array_var */',
                 $default_identifier_context,
             ],
+            [
+                [
+                    'array_var' => new ArrayType(new IntType(), []),
+                ],
+                '/** @param int[] $array_var */',
+                $default_identifier_context,
+            ],
         ];
     }
 }


### PR DESCRIPTION
## Summary

- Supports array types in the form of `@param array\<AtomicType\>`.
- Supports array types in the form of `@param int[]`.
- Supports union types like `@param int|string`.